### PR TITLE
Implement quiz history POST endpoint

### DIFF
--- a/backend/agent-squad/mcp-server.ts
+++ b/backend/agent-squad/mcp-server.ts
@@ -25,7 +25,7 @@ app.post("/ai", async (req, res) => {
 });
 
 // クイズ履歴取得API
-import { getQuizHistories } from "./services/quiz-history";
+import { getQuizHistories, logQuizHistory } from "./services/quiz-history";
 // 簡易認証ミドルウェア
 // LINE IDトークン認証ミドルウェア
 import { verifyLineIdToken } from "./services/line-jwt";
@@ -62,6 +62,21 @@ app.get("/quiz-history", requireAuth, async (req: Request, res: Response): Promi
   const histories = await getQuizHistories(userId, 20);
   res.json(histories);
   return;
+});
+
+// クイズ履歴登録API（linebotから利用）
+app.post("/quiz-history", async (req: Request, res: Response): Promise<void> => {
+  const { userId, quiz, answer, result } = req.body;
+  if (!userId || !quiz) {
+    res.status(400).json({ error: "userId and quiz required" });
+    return;
+  }
+  try {
+    const history = await logQuizHistory({ userId, quiz, answer, result });
+    res.status(201).json(history);
+  } catch (e) {
+    res.status(500).json({ error: "Failed to log quiz history" });
+  }
 });
 
 // 管理者API: admin claim（userId === "admin-user"）のみ全件取得

--- a/backend/agent-squad/tests/quiz-history.post.api.test.ts
+++ b/backend/agent-squad/tests/quiz-history.post.api.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import request from "supertest";
+
+// Prisma create mock
+const createMock = vi.fn().mockResolvedValue({
+  id: "1",
+  userId: "user-1",
+  quiz: '{"q":"test"}',
+  answer: "S3",
+  result: "正解",
+  createdAt: new Date(),
+});
+vi.mock("@prisma/client", () => {
+  return {
+    PrismaClient: vi.fn().mockImplementation(() => ({
+      quizHistory: {
+        create: createMock,
+      },
+    })),
+  };
+});
+
+let app: any;
+beforeAll(async () => {
+  const mod = await import("../mcp-server");
+  app = mod.app;
+});
+
+describe("POST /quiz-history", () => {
+  it("履歴を登録して結果を返す", async () => {
+    const payload = { userId: "user-1", quiz: { q: "test" }, answer: "S3", result: "正解" };
+    const res = await request(app).post("/quiz-history").send(payload).expect(201);
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        quiz: JSON.stringify({ q: "test" }),
+        answer: "S3",
+        result: "正解",
+      },
+    });
+    expect(res.body.userId).toBe("user-1");
+  });
+});


### PR DESCRIPTION
## Summary
- support POST `/quiz-history` in agent squad server for linebot to record quiz answers
- test the endpoint with Vitest

## Testing
- `pnpm run test` in `backend/linebot`
- `pnpm run test` in `backend/agent-squad`


------
https://chatgpt.com/codex/tasks/task_e_683f451115f483238b70332d11c29ae0