### PR TITLE
Add CDK directory and update deploy workflow

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,0 +1,30 @@
+name: CDK Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install AWS CDK
+        run: npm install -g aws-cdk
+
+      - name: Deploy CDK stacks
+        working-directory: cdk
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: npx cdk deploy --all --require-approval=never

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 
 ```
 /docs                # 要件・設計・技術資料
+/cdk                 # AWS CDK stacks
 /backend
   /agent-squad       # agent squad MCPサーバー
   /linebot           # LINE Bot Webhook/API

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,0 +1,3 @@
+# Infrastructure as Code
+
+Place AWS CDK stacks in this directory. The GitHub Actions workflow deploys from here.

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -7,6 +7,7 @@
   ├─ architecture.mmd      # アーキテクチャ設計図（Mermaid）
   ├─ folder-structure.md   # 本ファイル（構成・役割まとめ）
   ├─ deploy.md             # デプロイ手順・AWS移行ポイント
+/cdk                     # AWS CDK stacks
 /backend
   /agent-squad             # agent squad MCPサーバー（AI用途分担・拡張）
     ├─ mcp-server.ts
@@ -50,6 +51,6 @@
 ## 今後の拡張ポイント
 
 - /frontend（管理画面・Web UI追加時）
-- /infra（AWS CDK/terraform等のIaC）
+- /cdk（AWS CDKスタック置き場）
 - /backend/agent-squad/tools（新AI API追加時に拡張）
 - /backend/db（DynamoDB/RDS等への移行）


### PR DESCRIPTION
## Summary
- document new `/cdk` folder for CDK stacks
- run `npx cdk deploy` from the `/cdk` directory
- keep docs in sync with new structure

## Testing
- `pnpm run test` in `backend/linebot`
- `pnpm run test` in `backend/agent-squad`


------
https://chatgpt.com/codex/tasks/task_e_683fa33c1e2083239f9017d361361228