### PR TITLE
fix: update CDK deploy workflow for infra directory structure

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -21,8 +21,12 @@ jobs:
       - name: Install AWS CDK
         run: npm install -g aws-cdk
 
+      - name: Install CDK dependencies
+        working-directory: infra
+        run: npm install
+
       - name: Deploy CDK stacks
-        working-directory: cdk
+        working-directory: infra
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
• Fix CDK deploy workflow to use correct infra directory instead of cdk
• Add CDK dependencies installation step to ensure successful deployment

## Test plan
- [x] Verify workflow file syntax and structure
- [x] Test CDK dependencies installation locally
- [ ] Validate CI/CD pipeline execution on merge to main

🤖 Generated with [Claude Code](https://claude.ai/code)