### PR TITLE
fix: resolve CDK Docker asset infinite recursion issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.git
+.github
+docs
+infra/cdk.out
+infra/node_modules
+**/.env
+**/.env.local
+**/dist
+**/coverage
+**/*.log
+.DS_Store
+Thumbs.db

--- a/infra/lib/linebot-stack.ts
+++ b/infra/lib/linebot-stack.ts
@@ -29,6 +29,15 @@ export class LinebotStack extends cdk.Stack {
     const image = new ecrAssets.DockerImageAsset(this, 'ServiceImage', {
       directory: '../',
       file: 'Dockerfile',
+      exclude: [
+        'infra/cdk.out',
+        'infra/node_modules',
+        '**/.git',
+        '**/node_modules',
+        '**/dist',
+        '**/coverage',
+        '**/*.log'
+      ],
     });
 
     const taskRole = new iam.Role(this, 'TaskRole', {


### PR DESCRIPTION
## Summary
• Fix ENAMETOOLONG error in GitHub Actions CDK deployment
• Add .dockerignore to exclude problematic directories from Docker context
• Add explicit excludes in CDK DockerImageAsset to prevent infinite recursion

## Problem
CDK deployment was failing with `ENAMETOOLONG` error due to:
- DockerImageAsset copying entire project root including `infra/cdk.out`
- Infinite recursion creating extremely long file paths
- Exceeding filesystem path length limits

## Solution
• **`.dockerignore`**: Exclude git, node_modules, build artifacts, and CDK output
• **CDK excludes**: Explicitly exclude problematic directories in DockerImageAsset
• **Path optimization**: Prevent recursive directory inclusion

## Test plan
- [x] Verify .dockerignore syntax and coverage
- [x] Test CDK asset exclusion configuration
- [ ] Validate GitHub Actions CDK deployment succeeds
- [ ] Confirm Docker build works locally

🤖 Generated with [Claude Code](https://claude.ai/code)