### PR TITLE
fix: add deployment environment to CDK workflow

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: deployment
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
• Add `environment: deployment` to CDK deploy workflow
• Fix AWS credentials access from environment secrets
• Resolve "Unable to resolve AWS account" error in CDK deployment

## Problem
CDK deployment was failing with:
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` were empty
- Error: "Unable to resolve AWS account to use"
- Secrets not accessible from `deployment` environment

## Solution
• **Environment reference**: Add `environment: deployment` to job
• **Secret access**: Enable access to environment-scoped secrets
• **AWS authentication**: Proper credential resolution for CDK

## Test plan
- [x] Verify workflow syntax and environment reference
- [ ] Validate AWS credentials are populated in deployment
- [ ] Confirm CDK deploy succeeds with proper authentication

🤖 Generated with [Claude Code](https://claude.ai/code)