### PR TITLE
fix: resolve VPC availability zone configuration issue

### DIFF
--- a/infra/lib/linebot-stack.ts
+++ b/infra/lib/linebot-stack.ts
@@ -12,7 +12,9 @@ export class LinebotStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const vpc = new ec2.Vpc(this, 'Vpc', { maxAzs: 2 });
+    const vpc = new ec2.Vpc(this, 'Vpc', { 
+      maxAzs: Math.min(2, this.availabilityZones.length)
+    });
 
     const cluster = new ecs.Cluster(this, 'Cluster', { vpc, defaultCloudMapNamespace: { name: 'agent-squad' } });
 


### PR DESCRIPTION
## Summary
• Fix CloudFormation VPC deployment failure in regions with limited AZs
• Dynamically configure maxAzs based on available zones
• Resolve "Fn::Select cannot select nonexistent value at index 1" error

## Problem
CDK deployment was failing with CloudFormation error:
- `Fn::Select cannot select nonexistent value at index 1`
- VPC configuration assumed 2+ availability zones available
- Some AWS regions or accounts may have fewer AZs

## Solution
• **Dynamic AZ count**: Use `Math.min(2, this.availabilityZones.length)`
• **Region compatibility**: Support both single and multi-AZ deployments
• **Robust configuration**: Prevent template generation errors

## Test plan
- [x] Verify CDK synthesis works with single AZ
- [ ] Test deployment in limited AZ regions
- [ ] Confirm VPC creation succeeds with dynamic configuration

🤖 Generated with [Claude Code](https://claude.ai/code)